### PR TITLE
Fix double quotes escaping in Localizable.strings

### DIFF
--- a/LocalizationConverter/Formatters/LocalizableFormatter.swift
+++ b/LocalizationConverter/Formatters/LocalizableFormatter.swift
@@ -17,11 +17,15 @@ struct LocalizableFormatter {
         localizations.forEach { (key, localizationItem) in
             switch localizationItem {
             case .string(let value):
-                localizableEntries.append("\(key) = \"\(value)\";")
+                localizableEntries.append("\(key) = \"\(escapeDoubleQuotes(in: value))\";")
             case .plurals:
                 break
             }
         }
         return localizableEntries.sort { $0.lowercaseString < $1.lowercaseString }.joinWithSeparator("\n")
+    }
+
+    private func escapeDoubleQuotes(in string: String) -> String {
+        return string.stringByReplacingOccurrencesOfString("\"", withString: "\\\"")
     }
 }

--- a/LocalizationConverterTests/AcceptanceTests/testFiles/android/values-fr/strings.xml
+++ b/LocalizationConverterTests/AcceptanceTests/testFiles/android/values-fr/strings.xml
@@ -4,7 +4,7 @@
     <string name="Loading">Chargement…</string>
     <string name="Yes">Oui</string>
     <string name="No">Non</string>
-    <string name="Congratulations">Félicitations <b>%1$s</b> ! Vous l'avez fait !</string>
+    <string name="Congratulations">Félicitations "<b>%1$s</b>" ! Vous l'avez fait !</string>
     <plurals name="%d items">
         <item quantity="zero">Aucun élément</item>
         <item quantity="one">Un élément</item>

--- a/LocalizationConverterTests/AcceptanceTests/testFiles/android/values/strings.xml
+++ b/LocalizationConverterTests/AcceptanceTests/testFiles/android/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="Loading">Loading…</string>
     <string name="Yes">Yes</string>
     <string name="No">No</string>
-    <string name="Congratulations">Congratulations <b>%1$s</b>! You've done it!</string>
+    <string name="Congratulations">Congratulations "<b>%1$s</b>"! You've done it!</string>
     <plurals name="%d items">
         <item quantity="zero">No items</item>
         <item quantity="one">One item</item>

--- a/LocalizationConverterTests/AcceptanceTests/testFiles/ios/Base.lproj/Localizable.strings
+++ b/LocalizationConverterTests/AcceptanceTests/testFiles/ios/Base.lproj/Localizable.strings
@@ -1,5 +1,5 @@
 app.name = "Todo";
-Congratulations = "Congratulations <b>%1$@</b>! You've done it!";
+Congratulations = "Congratulations \"<b>%1$@</b>\"! You've done it!";
 Loading = "Loading…";
 No = "No";
 Yes = "Yes";

--- a/LocalizationConverterTests/AcceptanceTests/testFiles/ios/fr.lproj/Localizable.strings
+++ b/LocalizationConverterTests/AcceptanceTests/testFiles/ios/fr.lproj/Localizable.strings
@@ -1,5 +1,5 @@
 app.name = "Todo";
-Congratulations = "Félicitations <b>%1$@</b> ! Vous l'avez fait !";
+Congratulations = "Félicitations \"<b>%1$@</b>\" ! Vous l'avez fait !";
 Loading = "Chargement…";
 No = "Non";
 Yes = "Oui";

--- a/LocalizationConverterTests/Formatters/LocalizableFormatterTests.swift
+++ b/LocalizationConverterTests/Formatters/LocalizableFormatterTests.swift
@@ -89,4 +89,15 @@ class LocalizableFormatterTests: XCTestCase {
 
         XCTAssertEqual("positionalParams = \"Hello %1$@ %2$@!\";", resultLocalizableString)
     }
+
+    func test_format_escapeDoubleQuotes() {
+        let localizableFormatter = LocalizableFormatter()
+        let localization = LocalizationMap(type: .android, localizationsDictionary: [
+            "quotedString": LocalizationItem.string(value: "Hello \"Guest\"!"),
+            ])
+
+        let resultLocalizableString = localizableFormatter.format(localization)
+
+        XCTAssertEqual("quotedString = \"Hello \\\"Guest\\\"!\";", resultLocalizableString)
+    }
 }


### PR DESCRIPTION
#### This fixes issue #4 .
## What's in this pull request?
- add escaping of double quotes in output `Localizable.strings`
